### PR TITLE
go1.8 "Argument Liveness" might lead to early free

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -139,6 +139,7 @@ func (r *Rules) ScanMem(buf []byte, flags ScanFlags, timeout time.Duration) (mat
 		C.YR_CALLBACK_FUNC(C.rules_callback),
 		unsafe.Pointer(id),
 		C.int(timeout/time.Second)))
+	runtime.KeepAlive(r)
 	return
 }
 
@@ -155,6 +156,7 @@ func (r *Rules) ScanFile(filename string, flags ScanFlags, timeout time.Duration
 		C.YR_CALLBACK_FUNC(C.rules_callback),
 		unsafe.Pointer(id),
 		C.int(timeout/time.Second)))
+	runtime.KeepAlive(r)
 	return
 }
 
@@ -169,6 +171,7 @@ func (r *Rules) ScanProc(pid int, flags int, timeout time.Duration) (matches []M
 		C.YR_CALLBACK_FUNC(C.rules_callback),
 		unsafe.Pointer(id),
 		C.int(timeout/time.Second)))
+	runtime.KeepAlive(r)
 	return
 }
 
@@ -177,6 +180,7 @@ func (r *Rules) Save(filename string) (err error) {
 	cfilename := C.CString(filename)
 	defer C.free(unsafe.Pointer(cfilename))
 	err = newError(C.yr_rules_save(r.cptr, cfilename))
+	runtime.KeepAlive(r)
 	return
 }
 
@@ -237,5 +241,6 @@ func (r *Rules) DefineVariable(name string, value interface{}) (err error) {
 	default:
 		err = errors.New("wrong value type passed to DefineVariable; bool, int64, float64, string are accepted")
 	}
+	runtime.KeepAlive(r)
 	return
 }

--- a/rules.go
+++ b/rules.go
@@ -139,7 +139,7 @@ func (r *Rules) ScanMem(buf []byte, flags ScanFlags, timeout time.Duration) (mat
 		C.YR_CALLBACK_FUNC(C.rules_callback),
 		unsafe.Pointer(id),
 		C.int(timeout/time.Second)))
-	runtime.KeepAlive(r)
+	r.keepAlive()
 	return
 }
 
@@ -156,7 +156,7 @@ func (r *Rules) ScanFile(filename string, flags ScanFlags, timeout time.Duration
 		C.YR_CALLBACK_FUNC(C.rules_callback),
 		unsafe.Pointer(id),
 		C.int(timeout/time.Second)))
-	runtime.KeepAlive(r)
+	r.keepAlive()
 	return
 }
 
@@ -171,7 +171,7 @@ func (r *Rules) ScanProc(pid int, flags int, timeout time.Duration) (matches []M
 		C.YR_CALLBACK_FUNC(C.rules_callback),
 		unsafe.Pointer(id),
 		C.int(timeout/time.Second)))
-	runtime.KeepAlive(r)
+	r.keepAlive()
 	return
 }
 
@@ -180,7 +180,7 @@ func (r *Rules) Save(filename string) (err error) {
 	cfilename := C.CString(filename)
 	defer C.free(unsafe.Pointer(cfilename))
 	err = newError(C.yr_rules_save(r.cptr, cfilename))
-	runtime.KeepAlive(r)
+	r.keepAlive()
 	return
 }
 
@@ -241,6 +241,6 @@ func (r *Rules) DefineVariable(name string, value interface{}) (err error) {
 	default:
 		err = errors.New("wrong value type passed to DefineVariable; bool, int64, float64, string are accepted")
 	}
-	runtime.KeepAlive(r)
+	r.keepAlive()
 	return
 }

--- a/rules_keepalive.go
+++ b/rules_keepalive.go
@@ -1,0 +1,12 @@
+// Copyright © 2015-2017 Hilko Bengen <bengen@hilluzination.de>. All rights reserved.
+// Use of this source code is governed by the license that can be
+// found in the LICENSE file.
+
+// This file contains functionality for go prior in go1.7
+
+// +build !go1.7
+
+package yara
+
+func (r *Rules) keepAlive() {
+}

--- a/rules_keepalive_go17.go
+++ b/rules_keepalive_go17.go
@@ -1,0 +1,17 @@
+// Copyright © 2015-2017 Hilko Bengen <bengen@hilluzination.de>. All rights reserved.
+// Use of this source code is governed by the license that can be
+// found in the LICENSE file.
+
+// This file contains functionality available in go1.7 onward
+
+// +build go1.7
+
+package yara
+
+import (
+	"runtime"
+)
+
+func (r *Rules) keepAlive() {
+	runtime.KeepAlive(r)
+}

--- a/rules_test.go
+++ b/rules_test.go
@@ -137,6 +137,22 @@ func TestWriter(t *testing.T) {
 	}
 }
 
+// in Go 1.8 this code does not work in go-yara 1.0.2
+// go 1.8/debian stretch panics
+// go 1.8/darwin produces stack overflow
+func TestWriterBuffer(t *testing.T) {
+	rulesBuf := bytes.NewBuffer(nil)
+	for i := 0; i < 10000; i++ {
+		fmt.Fprintf(rulesBuf, "rule test%d : tag%d { meta: author = \"Hilko Bengen\" strings: $a = \"abc\" fullword condition: $a }", i, i)
+	}
+	r, _ := Compile(string(rulesBuf.Bytes()), nil)
+	buf := new(bytes.Buffer)
+	if err := r.Write(buf); err != nil {
+		t.Errorf("write to bytes.Buffer: %s", err)
+		return
+	}
+}
+
 // compress/bzip2 seems to return short reads which apparently leads
 // to YARA complaining about corrupt files. Tested with Go 1.4, 1.5.
 func TestReaderBZIP2(t *testing.T) {

--- a/rules_yara34.go
+++ b/rules_yara34.go
@@ -47,7 +47,7 @@ func (r *Rules) ScanFileDescriptor(fd uintptr, flags ScanFlags, timeout time.Dur
 		C.YR_CALLBACK_FUNC(C.rules_callback),
 		unsafe.Pointer(id),
 		C.int(timeout/time.Second)))
-	runtime.KeepAlive(r)
+	r.keepAlive()
 	return
 }
 
@@ -62,7 +62,7 @@ func (r *Rules) Write(wr io.Writer) (err error) {
 	stream.write = C.YR_STREAM_WRITE_FUNC(C.streamWrite)
 
 	err = newError(C.yr_rules_save_stream(r.cptr, stream))
-	runtime.KeepAlive(r)
+	r.keepAlive()
 	return
 }
 

--- a/rules_yara34.go
+++ b/rules_yara34.go
@@ -47,6 +47,7 @@ func (r *Rules) ScanFileDescriptor(fd uintptr, flags ScanFlags, timeout time.Dur
 		C.YR_CALLBACK_FUNC(C.rules_callback),
 		unsafe.Pointer(id),
 		C.int(timeout/time.Second)))
+	runtime.KeepAlive(r)
 	return
 }
 
@@ -61,6 +62,7 @@ func (r *Rules) Write(wr io.Writer) (err error) {
 	stream.write = C.YR_STREAM_WRITE_FUNC(C.streamWrite)
 
 	err = newError(C.yr_rules_save_stream(r.cptr, stream))
+	runtime.KeepAlive(r)
 	return
 }
 


### PR DESCRIPTION
In certain cases, the new [Argument Liveness](https://golang.org/doc/go1.8#liveness) in go1.8 can lead to early calls of rules' finalizer. `TestWriteBuffer` runs into this problem, as there is no reference in the test case and it runs long enough to get affected by the Garbage Collector during `r.Write`. Running `go test` using `GOGC=off` prevents this problem from showing up, as there are no Garbage Collector runs, but it also doesn't fix it ;)

Using `runtime.KeepAlive` prevents this, but is not available in go1.6. Therefore my approach here are custom wrappers using build tags.