### PR TITLE
Add link to GoDoc Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@
 
 Go bindings for [YARA](http://plusvic.github.io/yara/), staying as
 close as sensible to the library's C-API while taking inspiration from
-the `yara-python` implementation.
+the `yara-python` implementation. 
+
+## Documentation
+
+go-yara is documented on [GoDoc: hillu/go-yara](https://godoc.org/github.com/hillu/go-yara).
 
 ## Installation
 


### PR DESCRIPTION
It turns out that the repo doesn't contain much in the way of documentation, so I think a prominent link to the docs would be awesome. Adding some examples wouldn't be bad either (I'll add a PR for that later if I get some time).  