### PR TITLE
Update url to yara project

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Travis](https://travis-ci.org/hillu/go-yara.svg?branch=master)](https://travis-ci.org/hillu/go-yara)
 [![Go Report Card](https://goreportcard.com/badge/github.com/hillu/go-yara)](https://goreportcard.com/report/github.com/hillu/go-yara)
 
-Go bindings for [YARA](http://plusvic.github.io/yara/), staying as
+Go bindings for [YARA](https://virustotal.github.io/yara/), staying as
 close as sensible to the library's C-API while taking inspiration from
 the `yara-python` implementation.
 


### PR DESCRIPTION
Old link only forwards to a 404 if JavaScript is disabled.