### PR TITLE
Minor update to how rules testing works

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,17 +1,32 @@
 package yara
 
 import (
+	"io/ioutil"
+	"log"
 	"os"
 	"testing"
 )
 
+var compiledTestRulesPath string
+
 func TestMain(m *testing.M) {
-	if r, err := Compile(`rule test : tag1 { meta: author = "Hilko Bengen" strings: $a = "abc" fullword condition: $a }`, nil); err != nil {
-		os.Exit(1)
-	} else if err = r.Save("testrules.yac"); err != nil {
-		os.Exit(1)
+	r, err := Compile(`rule test : tag1 { meta: author = "Hilko Bengen" strings: $a = "abc" fullword condition: $a }`, nil)
+	if err != nil {
+		log.Fatalf("Compile: %v", err)
 	}
+
+	f, err := ioutil.TempFile("", "testrules.yac")
+	if err != nil {
+		log.Fatalf("ioutil.TempFile: %v", err)
+	}
+	compiledTestRulesPath = f.Name()
+
+	if err := r.Save(compiledTestRulesPath); err != nil {
+		os.Remove(compiledTestRulesPath)
+		log.Fatalf("Save(%q): %v", compiledTestRulesPath, err)
+	}
+
 	rc := m.Run()
-	os.Remove("testrules.yac")
+	os.Remove(compiledTestRulesPath)
 	os.Exit(rc)
 }

--- a/rules_test.go
+++ b/rules_test.go
@@ -96,14 +96,14 @@ func assertFalseRules(t *testing.T, rules []string, data []byte) {
 }
 
 func TestLoad(t *testing.T) {
-	r, err := LoadRules("testrules.yac")
+	r, err := LoadRules(compiledTestRulesPath)
 	if r == nil || err != nil {
 		t.Fatalf("LoadRules: %s", err)
 	}
 }
 
 func TestReader(t *testing.T) {
-	rd, err := os.Open("testrules.yac")
+	rd, err := os.Open(compiledTestRulesPath)
 	if err != nil {
 		t.Fatalf("os.Open: %s", err)
 	}
@@ -119,7 +119,7 @@ func TestReader(t *testing.T) {
 }
 
 func TestWriter(t *testing.T) {
-	rd, err := os.Open("testrules.yac")
+	rd, err := os.Open(compiledTestRulesPath)
 	if err != nil {
 		t.Fatalf("os.Open: %s", err)
 	}


### PR DESCRIPTION
Our environment doesn't allow a writable directory when unit tests are run. As main_test.go tries to write to the cwd, tests fail. This change uses a ioutil.TempFile to create a safe temporary file that can store the rules compiled at runtime and later used in other test cases.