### PR TITLE
Introduce ScanCallbackModuleImportWrapped to get rid of memory leak

### DIFF
--- a/cbytes.go
+++ b/cbytes.go
@@ -1,0 +1,24 @@
+// Copyright © 2015-2017 Hilko Bengen <bengen@hilluzination.de>. All rights reserved.
+// Use of this source code is governed by the license that can be
+// found in the LICENSE file.
+
+// +build !go1.7
+
+package yara
+
+// #include <stdlib.h>
+import "C"
+import (
+	"reflect"
+	"unsafe"
+)
+
+func cBytes(data []byte) (unsafe.Pointer, C.size_t) {
+	cbuf := C.malloc(C.size_t(len(data)))
+
+	outbuf := make([]byte, 0)
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&outbuf))
+	hdr.Data, hdr.Len, hdr.Cap = uintptr(cbuf), len(data), len(data)
+	copy(outbuf, data)
+	return cbuf, C.size_t(len(data))
+}

--- a/cbytes_go17.go
+++ b/cbytes_go17.go
@@ -1,0 +1,14 @@
+// Copyright © 2015-2017 Hilko Bengen <bengen@hilluzination.de>. All rights reserved.
+// Use of this source code is governed by the license that can be
+// found in the LICENSE file.
+
+// +build go1.7
+
+package yara
+
+import "C"
+import "unsafe"
+
+func cBytes(data []byte) (unsafe.Pointer, C.size_t) {
+	return C.CBytes(data), C.size_t(len(data))
+}


### PR DESCRIPTION
Currently, `ScanCallbackModuleImport` leaks memory by design. Introduce ModuleData wrapper to prevent this and deprecate `ScanCallbackModuleImport`.