### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,7 +15,7 @@ type ConfigName uint32
 
 const ConfigStackSize ConfigName = C.YR_CONFIG_STACK_SIZE
 
-// SetCnofiguration sets a global YARA configuration option.
+// SetConfiguration sets a global YARA configuration option.
 func SetConfiguration(name ConfigName, src interface{}) error {
 	i, ok := src.(int)
 	if !ok {

--- a/rule.go
+++ b/rule.go
@@ -150,12 +150,12 @@ func (r *Rule) Metas() (metas map[string]interface{}) {
 	return
 }
 
-// Returns true if the rule is marked as private
+// IsPrivate returns true if the rule is marked as private
 func (r *Rule) IsPrivate() bool {
 	return (r.cptr.g_flags & C.RULE_GFLAGS_PRIVATE) != 0
 }
 
-// Returns true if the rule is marked as global
+// IsGlobal returns true if the rule is marked as global
 func (r *Rule) IsGlobal() bool {
 	return (r.cptr.g_flags & C.RULE_GFLAGS_GLOBAL) != 0
 }

--- a/rules_yara34.go
+++ b/rules_yara34.go
@@ -55,7 +55,7 @@ func (r *Rules) ScanFileDescriptor(fd uintptr, flags ScanFlags, timeout time.Dur
 	return
 }
 
-// ScanFileDescriptor scans a file using the ruleset. For every event
+// ScanFileDescriptorWithCallback scans a file using the ruleset. For every event
 // emitted by libyara, the appropriate method on the ScanCallback
 // object is called.
 func (r *Rules) ScanFileDescriptorWithCallback(fd uintptr, flags ScanFlags, timeout time.Duration, cb ScanCallback) (err error) {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?