### PR TITLE
Add Scanner for YR_SCANNER

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -36,6 +36,8 @@ import (
 // Scanner contains a YARA scanner
 type Scanner struct {
 	*scanner
+	// The Scanner struct has to hold a pointer to the rules
+	// it wraps, as otherwise it may be be garbage collected.
 	rules *Rules
 }
 

--- a/scanner.go
+++ b/scanner.go
@@ -1,0 +1,38 @@
+// Copyright © 2015-2019 Hilko Bengen <bengen@hilluzination.de>
+// All rights reserved.
+//
+// Use of this source code is governed by the license that can be
+// found in the LICENSE file.
+
+package yara
+
+/*
+#include <stdio.h>
+#include <unistd.h>
+#include <yara.h>
+
+int scanCallbackFunc(int, void*, void*);
+*/
+import "C"
+import "runtime"
+
+// Scanner contains a YARA scanner
+type Scanner struct {
+	*scanner
+}
+
+type scanner struct {
+	cptr *C.YR_SCANNER
+}
+
+// NewScanner creates a YARA scanner.
+func NewScanner() (*Scanner, error) {
+	var yrScanner *C.YR_SCANNER
+	s := &Scanner{scanner: &scanner{cptr: yrScanner}}
+	return s, nil
+}
+
+func (s *scanner) finalize() {
+	C.yr_scanner_destroy(s.cptr)
+	runtime.SetFinalizer(s, nil)
+}

--- a/scanner.go
+++ b/scanner.go
@@ -4,17 +4,34 @@
 // Use of this source code is governed by the license that can be
 // found in the LICENSE file.
 
+// +build !yara3.3,!yara3.4,!yara3.5,!yara3.6,!yara3.7
+
 package yara
 
 /*
-#include <stdio.h>
-#include <unistd.h>
 #include <yara.h>
+
+#ifdef _WIN32
+#include <stdint.h>
+int _yr_scanner_scan_fd(
+    YR_SCANNER* scanner,
+    int fd)
+{
+  return yr_scanner_scan_fd(scanner, (YR_FILE_DESCRIPTOR)(intptr_t)fd);
+}
+#else
+#define _yr_scanner_scan_fd yr_scanner_scan_fd
+#endif
 
 int scanCallbackFunc(int, void*, void*);
 */
 import "C"
-import "runtime"
+import (
+	"errors"
+	"runtime"
+	"time"
+	"unsafe"
+)
 
 // Scanner contains a YARA scanner
 type Scanner struct {
@@ -26,13 +43,186 @@ type scanner struct {
 }
 
 // NewScanner creates a YARA scanner.
-func NewScanner() (*Scanner, error) {
+func NewScanner(r *Rules) (*Scanner, error) {
 	var yrScanner *C.YR_SCANNER
+	if err := newError(C.yr_scanner_create(r.cptr, &yrScanner)); err != nil {
+		return nil, err
+	}
 	s := &Scanner{scanner: &scanner{cptr: yrScanner}}
+	runtime.SetFinalizer(s.scanner, (*scanner).finalize)
 	return s, nil
 }
 
 func (s *scanner) finalize() {
 	C.yr_scanner_destroy(s.cptr)
 	runtime.SetFinalizer(s, nil)
+}
+
+// Destroy destroys the YARA data structure representing a scanner.
+// Since a Finalizer for the underlying YR_SCANNER structure is
+// automatically set up on creation, it should not be necessary to
+// explicitly all this method.
+func (s *Scanner) Destroy() {
+	if s.scanner != nil {
+		s.scanner.finalize()
+		s.scanner = nil
+	}
+}
+
+// DefineVariable defines a named variable for use by the scanner.
+// Boolean, int64, float64, and string types are supported.
+func (s *Scanner) DefineVariable(identifier string, value interface{}) (err error) {
+	cid := C.CString(identifier)
+	defer C.free(unsafe.Pointer(cid))
+	switch value.(type) {
+	case bool:
+		var v int
+		if value.(bool) {
+			v = 1
+		}
+		err = newError(C.yr_scanner_define_boolean_variable(
+			s.cptr, cid, C.int(v)))
+	case int, int8, int16, int32, int64, uint, uint8, uint32, uint64:
+		value := toint64(value)
+		err = newError(C.yr_scanner_define_integer_variable(
+			s.cptr, cid, C.int64_t(value)))
+	case float64:
+		err = newError(C.yr_scanner_define_float_variable(
+			s.cptr, cid, C.double(value.(float64))))
+	case string:
+		cvalue := C.CString(value.(string))
+		defer C.free(unsafe.Pointer(cvalue))
+		err = newError(C.yr_scanner_define_string_variable(
+			s.cptr, cid, cvalue))
+	default:
+		err = errors.New("wrong value type passed to DefineVariable; bool, int64, float64, string are accepted")
+	}
+	keepAlive(s)
+	return
+}
+
+// ScanMem scans an in-memory buffer using the scanner, returning
+// matches via a list of MatchRule objects.
+func (s *Scanner) ScanMem(buf []byte, flags ScanFlags, timeout time.Duration) (matches []MatchRule, err error) {
+	cb := MatchRules{}
+	err = s.ScanMemWithCallback(buf, flags, timeout, &cb)
+	matches = cb
+	return
+}
+
+// ScanMemWithCallback scans an in-memory buffer using the scanner.
+// For every event emitted by libyara, the appropriate method on the
+// ScanCallback object is called.
+func (s *Scanner) ScanMemWithCallback(buf []byte, flags ScanFlags, timeout time.Duration, cb ScanCallback) (err error) {
+	var ptr *C.uint8_t
+	if len(buf) > 0 {
+		ptr = (*C.uint8_t)(unsafe.Pointer(&(buf[0])))
+	}
+	cbc := &scanCallbackContainer{ScanCallback: cb}
+	defer cbc.destroy()
+	id := callbackData.Put(cbc)
+	defer callbackData.Delete(id)
+
+	C.yr_scanner_set_flags(s.cptr, C.int(flags))
+	C.yr_scanner_set_timeout(s.cptr, C.int(timeout/time.Second))
+	C.yr_scanner_set_callback(s.cptr, C.YR_CALLBACK_FUNC(C.scanCallbackFunc), id)
+
+	err = newError(C.yr_scanner_scan_mem(
+		s.cptr,
+		ptr,
+		C.size_t(len(buf))))
+	keepAlive(s)
+	return
+}
+
+// ScanFile scans a file using the scanner, returning
+// matches via a list of MatchRule objects.
+func (s *Scanner) ScanFile(filename string, flags ScanFlags, timeout time.Duration) (matches []MatchRule, err error) {
+	cb := MatchRules{}
+	err = s.ScanFileWithCallback(filename, flags, timeout, &cb)
+	matches = cb
+	return
+}
+
+// ScanFileWithCallback scans a file using the scanner.
+// For every event emitted by libyara, the appropriate method on the
+// ScanCallback object is called.
+func (s *Scanner) ScanFileWithCallback(filename string, flags ScanFlags, timeout time.Duration, cb ScanCallback) (err error) {
+	cfilename := C.CString(filename)
+	defer C.free(unsafe.Pointer(cfilename))
+	cbc := &scanCallbackContainer{ScanCallback: cb}
+	defer cbc.destroy()
+	id := callbackData.Put(cbc)
+	defer callbackData.Delete(id)
+
+	C.yr_scanner_set_flags(s.cptr, C.int(flags))
+	C.yr_scanner_set_timeout(s.cptr, C.int(timeout/time.Second))
+	C.yr_scanner_set_callback(s.cptr, C.YR_CALLBACK_FUNC(C.scanCallbackFunc), id)
+
+	err = newError(C.yr_scanner_scan_file(
+		s.cptr,
+		cfilename,
+	))
+	keepAlive(s)
+	return
+}
+
+// ScanFileDescriptor scans a file using the scanner, returning
+// matches via a list of MatchRule objects.
+func (s *Scanner) ScanFileDescriptor(fd uintptr, flags ScanFlags, timeout time.Duration) (matches []MatchRule, err error) {
+	cb := MatchRules{}
+	err = s.ScanFileDescriptorWithCallback(fd, flags, timeout, &cb)
+	matches = cb
+	return
+}
+
+// ScanFileDescriptorWithCallback scans a file using the scanner. For every event
+// emitted by libyara, the appropriate method on the ScanCallback
+// object is called.
+func (s *Scanner) ScanFileDescriptorWithCallback(fd uintptr, flags ScanFlags, timeout time.Duration, cb ScanCallback) (err error) {
+	cbc := &scanCallbackContainer{ScanCallback: cb}
+	defer cbc.destroy()
+	id := callbackData.Put(cbc)
+	defer callbackData.Delete(id)
+
+	C.yr_scanner_set_flags(s.cptr, C.int(flags))
+	C.yr_scanner_set_timeout(s.cptr, C.int(timeout/time.Second))
+	C.yr_scanner_set_callback(s.cptr, C.YR_CALLBACK_FUNC(C.scanCallbackFunc), id)
+
+	err = newError(C.yr_scanner_scan_fd(
+		s.cptr,
+		C.int(fd),
+	))
+	keepAlive(s)
+	return
+}
+
+// ScanProc scans a live process using the scanner, returning matches
+// via a list of MatchRule objects.
+func (s *Scanner) ScanProc(pid int, flags ScanFlags, timeout time.Duration) (matches []MatchRule, err error) {
+	cb := MatchRules{}
+	err = s.ScanProcWithCallback(pid, flags, timeout, &cb)
+	matches = cb
+	return
+}
+
+// ScanProcWithCallback scans a live process using the scanner.
+// For every event emitted by libyara, the appropriate method on the
+// ScanCallback object is called.
+func (s *Scanner) ScanProcWithCallback(pid int, flags ScanFlags, timeout time.Duration, cb ScanCallback) (err error) {
+	cbc := &scanCallbackContainer{ScanCallback: cb}
+	defer cbc.destroy()
+	id := callbackData.Put(cbc)
+	defer callbackData.Delete(id)
+
+	C.yr_scanner_set_flags(s.cptr, C.int(flags))
+	C.yr_scanner_set_timeout(s.cptr, C.int(timeout/time.Second))
+	C.yr_scanner_set_callback(s.cptr, C.YR_CALLBACK_FUNC(C.scanCallbackFunc), id)
+
+	err = newError(C.yr_scanner_scan_proc(
+		s.cptr,
+		C.int(pid),
+	))
+	keepAlive(s)
+	return
 }

--- a/scanner.go
+++ b/scanner.go
@@ -36,6 +36,7 @@ import (
 // Scanner contains a YARA scanner
 type Scanner struct {
 	*scanner
+	rules *Rules
 }
 
 type scanner struct {
@@ -48,7 +49,7 @@ func NewScanner(r *Rules) (*Scanner, error) {
 	if err := newError(C.yr_scanner_create(r.cptr, &yrScanner)); err != nil {
 		return nil, err
 	}
-	s := &Scanner{scanner: &scanner{cptr: yrScanner}}
+	s := &Scanner{scanner: &scanner{cptr: yrScanner}, rules: r}
 	runtime.SetFinalizer(s.scanner, (*scanner).finalize)
 	return s, nil
 }

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -1,0 +1,165 @@
+package yara
+
+import (
+	"io/ioutil"
+	"os"
+	"runtime"
+	"testing"
+)
+
+func makeScanner(t *testing.T, rule string) *Scanner {
+	c, err := NewCompiler()
+	if c == nil || err != nil {
+		t.Fatal("NewCompiler():", err)
+	}
+	if err = c.AddString(rule, ""); err != nil {
+		t.Fatal("AddString():", err)
+	}
+	r, err := c.GetRules()
+	if err != nil {
+		t.Fatal("GetRules:", err)
+	}
+	s, err := NewScanner(r)
+	if err != nil {
+		t.Fatal("NewScanner:", err)
+	}
+	return s
+}
+
+func TestScannerSimpleMatch(t *testing.T) {
+	s := makeScanner(t,
+		"rule test : tag1 { meta: author = \"Matt Blewitt\" strings: $a = \"abc\" fullword condition: $a }")
+	m, err := s.ScanMem([]byte(" abc "), 0, 0)
+	if err != nil {
+		t.Errorf("ScanMem: %s", err)
+	}
+	t.Logf("Matches: %+v", m)
+}
+
+func TestScannerSimpleFileMatch(t *testing.T) {
+	s := makeScanner(t,
+		"rule test : tag1 { meta: author = \"Matt Blewitt\" strings: $a = \"abc\" fullword condition: $a }")
+	tf, _ := ioutil.TempFile("", "TestScannerSimpleFileMatch")
+	defer os.Remove(tf.Name())
+	tf.Write([]byte(" abc "))
+	tf.Close()
+	m, err := s.ScanFile(tf.Name(), 0, 0)
+	if err != nil {
+		t.Errorf("ScanFile(%s): %s", tf.Name(), err)
+	}
+	t.Logf("Matches: %+v", m)
+}
+
+func TestScannerSimpleFileDescriptorMatch(t *testing.T) {
+	s := makeScanner(t,
+		"rule test : tag1 { meta: author = \"Matt Blewitt\" strings: $a = \"abc\" fullword condition: $a }")
+	tf, _ := ioutil.TempFile("", "TestScannerSimpleFileDescriptorMatch")
+	defer os.Remove(tf.Name())
+	tf.Write([]byte(" abc "))
+	tf.Seek(0, os.SEEK_SET)
+	m, err := s.ScanFileDescriptor(tf.Fd(), 0, 0)
+	if err != nil {
+		t.Errorf("ScanFileDescriptor(%v): %s", tf.Fd(), err)
+	}
+	t.Logf("Matches: %+v", m)
+
+}
+
+// TestScannerIndependence tests that two scanners can
+// execute with different external variables and the same ruleset
+func TestScannerIndependence(t *testing.T) {
+	rulesStr := `
+		rule test {
+			condition: bool_var and int_var == 1 and str_var == "foo"
+		}
+	`
+
+	c, err := NewCompiler()
+	if c == nil || err != nil {
+		t.Fatal("NewCompiler():", err)
+	}
+
+	c.DefineVariable("bool_var", false)
+	c.DefineVariable("int_var", 0)
+	c.DefineVariable("str_var", "")
+
+	if err = c.AddString(rulesStr, ""); err != nil {
+		t.Fatal("AddString():", err)
+	}
+
+	r, err := c.GetRules()
+	if err != nil {
+		t.Fatal("GetRules:", err)
+	}
+
+	s1, err := NewScanner(r)
+	if err != nil {
+		t.Fatal("NewScanner:", err)
+	}
+
+	s2, err := NewScanner(r)
+	if err != nil {
+		t.Fatal("NewScanner:", err)
+	}
+
+	s1.DefineVariable("bool_var", true)
+	s1.DefineVariable("int_var", 1)
+	s1.DefineVariable("str_var", "foo")
+
+	s2.DefineVariable("bool_var", false)
+	s2.DefineVariable("int_var", 2)
+	s2.DefineVariable("str_var", "bar")
+
+	m1, err := s1.ScanMem([]byte(""), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m2, err := s2.ScanMem([]byte(""), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !(len(m1) > 0) {
+		t.Errorf("wanted >0 matches, got %d", len(m1))
+	}
+
+	if len(m2) != 0 {
+		t.Errorf("wanted 0 matches, got %d", len(m2))
+	}
+
+	t.Logf("Matches 1: %+v", m1)
+	t.Logf("Matches 2: %+v", m2)
+}
+
+func TestScannerImportDataCallback(t *testing.T) {
+	cb := newTestCallback(t)
+	s := makeScanner(t, `
+		import "tests"
+		import "pe"
+		rule t1 { condition: true }
+		rule t2 { condition: false }
+		rule t3 {
+			condition: tests.module_data == "callback-data-for-tests-module"
+		}`)
+	if err := s.ScanMemWithCallback([]byte(""), 0, 0, cb); err != nil {
+		t.Error(err)
+	}
+	for _, module := range []string{"tests", "pe"} {
+		if _, ok := cb.modules[module]; !ok {
+			t.Errorf("ImportModule was not called for %s", module)
+		}
+	}
+	for _, rule := range []string{"t1", "t3"} {
+		if _, ok := cb.matched["t1"]; !ok {
+			t.Errorf("RuleMatching was not called for %s", rule)
+		}
+	}
+	if _, ok := cb.notMatched["t2"]; !ok {
+		t.Errorf("RuleNotMatching was not called for %s", "t2")
+	}
+	if !cb.finished {
+		t.Errorf("ScanFinished was not called")
+	}
+	runtime.GC()
+}

--- a/stress_test.go
+++ b/stress_test.go
@@ -45,7 +45,76 @@ func TestFileWalk(t *testing.T) {
 				if !info.Mode().IsRegular() || info.Size() >= 2000000 {
 					return nil
 				}
+				// r.DefineVariable("filename", info.Name())
+				// r.DefineVariable("filepath", name)
 				if m, err := r.ScanFile(name, 0, 0); err == nil {
+					fmt.Printf("[%02d] Scan \"%s\": %d\n", i, path.Base(name), len(m))
+				} else {
+					fmt.Printf("[%02d] Scan \"%s\": %s\n", i, path.Base(name), err)
+				}
+				return nil
+			})
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestScannerFileWalk(t *testing.T) {
+	if os.ExpandEnv("${TEST_WALK}") == "" {
+		t.Skip("Set TEST_WALK to enable scanning files from user's HOME with a dummy ruleset.\n" +
+			"(Setting -test.timeout may be a good idea for this.)")
+	}
+	initialPath := os.ExpandEnv("${TEST_WALK_START}")
+	if initialPath == "" {
+		if u, err := user.Current(); err != nil {
+			t.Skip("Could get user's homedir. You can use TEST_WALK_START " +
+				"to set an initial path for filepath.Walk()")
+		} else {
+			initialPath = u.HomeDir
+		}
+	}
+	r, err := Compile(`
+		rule test: tag1 tag2 tag3 {
+			meta:
+				foo = 1
+				bar = "xxx"
+				quux = false
+			condition:
+				true
+		}
+	`, map[string]interface{}{
+		"filename": "",
+		"filepath": "",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wg := sync.WaitGroup{}
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func(i int) {
+			filepath.Walk(initialPath, func(name string, info os.FileInfo, inErr error) error {
+				fmt.Printf("[%02d] %s\n", i, name)
+				if inErr != nil {
+					fmt.Printf("[%02d] Walk to \"%s\": %s\n", i, name, inErr)
+					return nil
+				}
+				if info.IsDir() && info.Mode()&os.ModeSymlink != 0 {
+					fmt.Printf("[%02d] Walk to \"%s\": Skipping symlink\n", i, name)
+					return filepath.SkipDir
+				}
+				if !info.Mode().IsRegular() || info.Size() >= 2000000 {
+					return nil
+				}
+				s, err := NewScanner(r)
+				if err != nil {
+					t.Fatal(err)
+				}
+				s.DefineVariable("filepath", name)
+				s.DefineVariable("filename", info.Name())
+				if m, err := s.ScanFile(name, 0, 0); err == nil {
 					fmt.Printf("[%02d] Scan \"%s\": %d\n", i, path.Base(name), len(m))
 				} else {
 					fmt.Printf("[%02d] Scan \"%s\": %s\n", i, path.Base(name), err)


### PR DESCRIPTION
Hello!

Inspired by @plusvic's comment here: https://github.com/hillu/go-yara/pull/21#issuecomment-362015462 and my own requirements (concurrent access to a `Rules` object with different external variables set), this PR implements an interface to `YR_SCANNER`, behaving much like the existing `YR_RULES` interface.

In order to provide an easier drop in wrapper for `Rules`, rather than having to explicitly call `s.AddCallback()` and friends, this is done in the initialiser in this version. Should the goal of the project to be closely mapping to the C API, happy to pull these out into their own methods on `Scanner`.

An additional stress test has also been added to make sure the concurrent access problem doesn't arise, as it does with `Rules`. A test to check `Scanner` independence was also added, lifted shamelessly from https://github.com/VirusTotal/yara/blob/master/tests/test-api.c#L354.