### PR TITLE
Add wrappers for yr_scanner_last_error_rule and yr_scanner_last_error_string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
- - 1.6.x
  - 1.7.x
  - 1.8.x
  - 1.9.x

--- a/scanner.go
+++ b/scanner.go
@@ -223,3 +223,27 @@ func (s *Scanner) ScanProc(pid int) (matches []MatchRule, err error) {
 	keepAlive(s)
 	return
 }
+
+// GetLastErrorRule returns the Rule which caused the last error
+//
+// The result is nil, if scanner returned no rule
+func (s *Scanner) GetLastErrorRule() (r *Rule) {
+	ptr := C.yr_scanner_last_error_rule(s.cptr)
+	if ptr != nil {
+		r = &Rule{ptr}
+	}
+	runtime.KeepAlive(s)
+	return
+}
+
+// GetLastErrorString returns the String which caused the last error
+//
+// The result is nil, if scanner returned no string
+func (s *Scanner) GetLastErrorString() (r *String) {
+	ptr := C.yr_scanner_last_error_string(s.cptr)
+	if ptr != nil {
+		r = &String{ptr}
+	}
+	runtime.KeepAlive(s)
+	return
+}


### PR DESCRIPTION
This PR adds support for the two `Scanner` functions
* `yr_scanner_last_error_rule`
* `yr_scanner_last_error_string`

These allow to receive additional information in case of a failing scanner.

It was not possible to add the same for the `Rules` object, since `yr_rules_*` does not provide this kind of functionality.

At the moment this PR should be applied after #63 gets merged and does not support Go 1.6.
Therefore it uses `runtime.KeepAlive` instead of `keepAlive`.