### PR TITLE
RfC: Breaking changes for v4

### DIFF
--- a/_examples/simple-yara/simple-yara.go
+++ b/_examples/simple-yara/simple-yara.go
@@ -108,13 +108,13 @@ func main() {
 	if processScan {
 		for _, pid := range pids {
 			log.Printf("Scanning process %d...", pid)
-			m, err := r.ScanProc(pid, 0, 0)
+			m, err := r.ScanProc(pid, 0, 0, nil)
 			printMatches(m, err)
 		}
 	} else {
 		for _, filename := range args {
 			log.Printf("Scanning file %s... ", filename)
-			m, err := r.ScanFile(filename, 0, 0)
+			m, err := r.ScanFile(filename, 0, 0, nil)
 			printMatches(m, err)
 		}
 	}

--- a/example_mem_blocks_test.go
+++ b/example_mem_blocks_test.go
@@ -83,7 +83,8 @@ rule B {
 }
 	`, nil)
 
-	mrs, err := rs.ScanMemBlocks(it, 0, 0)
+	var mrs yara.MatchRules
+	err := rs.ScanMemBlocks(it, 0, 0, &mrs)
 	if err != nil {
 		fmt.Printf("error: %+v\n", err)
 		return

--- a/mem_blocks_test.go
+++ b/mem_blocks_test.go
@@ -51,13 +51,13 @@ condition: $a at 0 and $b at 32
 
 `, nil)
 	var mrs MatchRules
-	if err := rs.ScanMemBlocksWithCallback(&testIter{}, 0, 0, &mrs); err != nil {
+	if err := rs.ScanMemBlocks(&testIter{}, 0, 0, &mrs); err != nil {
 		t.Errorf("simple iterator scan (no data): %v", err)
 	} else {
 		t.Logf("simple iterator scan (no data): %v", mrs)
 	}
 	mrs = nil
-	if err := rs.ScanMemBlocksWithCallback(&testIter{
+	if err := rs.ScanMemBlocks(&testIter{
 		data: []block{{0, nil}},
 	}, 0, 0, &mrs); err != nil {
 		t.Errorf("simple iterator scan (empty block): %v", err)
@@ -65,7 +65,7 @@ condition: $a at 0 and $b at 32
 		t.Logf("simple iterator scan (empty block): %+v", mrs)
 	}
 	mrs = nil
-	if err := rs.ScanMemBlocksWithCallback(&testIter{
+	if err := rs.ScanMemBlocks(&testIter{
 		data: []block{
 			{0, []byte("aaaaaaaaaaaaaaaa")},
 			{32, []byte("bbbbbbbbbbbbbbbb")},

--- a/ported_test.go
+++ b/ported_test.go
@@ -309,7 +309,8 @@ func TestHexStrings(t *testing.T) {
 	}, []byte("123456789"))
 
 	rules := makeRules(t, "rule test { strings: $a = { 61 [0-3] (62|63) } condition: $a }")
-	matches, _ := rules.ScanMem([]byte("abbb"), 0, 0)
+	var matches MatchRules
+	rules.ScanMem([]byte("abbb"), 0, 0, &matches)
 	if matches[0].Strings[0].Name != "$a" ||
 		matches[0].Strings[0].Offset != 0 ||
 		string(matches[0].Strings[0].Data) != "ab" {
@@ -381,7 +382,8 @@ func TestExternals(t *testing.T) {
 			t.Errorf("rule=%s params=%+v: Compile error: %s", sample.rule, sample.params, err)
 			continue
 		}
-		m, _ := r.ScanMem([]byte("dummy"), 0, 0)
+		var m MatchRules
+		r.ScanMem([]byte("dummy"), 0, 0, &m)
 		if sample.predicate != (len(m) > 0) {
 			t.Errorf("rule=%s params=%+v: expected %t, got %t",
 				sample.rule, sample.params, sample.predicate, (len(m) > 0))

--- a/rules.go
+++ b/rules.go
@@ -81,25 +81,15 @@ const (
 	ScanFlagsProcessMemory = C.SCAN_FLAGS_PROCESS_MEMORY
 )
 
-// ScanMem scans an in-memory buffer using the ruleset, returning
-// matches via a list of MatchRule objects.
-func (r *Rules) ScanMem(buf []byte, flags ScanFlags, timeout time.Duration) (matches []MatchRule, err error) {
-	cb := MatchRules{}
-	err = r.ScanMemWithCallback(buf, flags, timeout, &cb)
-	matches = cb
-	return
-}
-
-// ScanMemWithCallback scans an in-memory buffer using the ruleset.
-// For every event emitted by libyara, the appropriate method on the
+// ScanMem scans an in-memory buffer using the ruleset.
+// For every event emitted by libyara, the corresponding method on the
 // ScanCallback object is called.
-func (r *Rules) ScanMemWithCallback(buf []byte, flags ScanFlags, timeout time.Duration, cb ScanCallback) (err error) {
+func (r *Rules) ScanMem(buf []byte, flags ScanFlags, timeout time.Duration, cb ScanCallback) (err error) {
 	var ptr *C.uint8_t
 	if len(buf) > 0 {
 		ptr = (*C.uint8_t)(unsafe.Pointer(&(buf[0])))
 	}
-	cbc := makeScanCallbackContainer(cb)
-	id := callbackData.Put(cbc)
+	id := callbackData.Put(makeScanCallbackContainer(cb))
 	defer callbackData.Delete(id)
 	err = newError(C.yr_rules_scan_mem(
 		r.cptr,
@@ -113,19 +103,10 @@ func (r *Rules) ScanMemWithCallback(buf []byte, flags ScanFlags, timeout time.Du
 	return
 }
 
-// ScanFile scans a file using the ruleset, returning matches via a
-// list of MatchRule objects.
-func (r *Rules) ScanFile(filename string, flags ScanFlags, timeout time.Duration) (matches []MatchRule, err error) {
-	cb := MatchRules{}
-	err = r.ScanFileWithCallback(filename, flags, timeout, &cb)
-	matches = cb
-	return
-}
-
-// ScanFileWithCallback scans a file using the ruleset. For every
-// event emitted by libyara, the appropriate method on the
+// ScanFile scans a file using the ruleset. For every
+// event emitted by libyara, the corresponding method on the
 // ScanCallback object is called.
-func (r *Rules) ScanFileWithCallback(filename string, flags ScanFlags, timeout time.Duration, cb ScanCallback) (err error) {
+func (r *Rules) ScanFile(filename string, flags ScanFlags, timeout time.Duration, cb ScanCallback) (err error) {
 	cfilename := C.CString(filename)
 	defer C.free(unsafe.Pointer(cfilename))
 	id := callbackData.Put(makeScanCallbackContainer(cb))
@@ -141,19 +122,10 @@ func (r *Rules) ScanFileWithCallback(filename string, flags ScanFlags, timeout t
 	return
 }
 
-// ScanFileDescriptor scans a file using the ruleset, returning
-// matches via a list of MatchRule objects.
-func (r *Rules) ScanFileDescriptor(fd uintptr, flags ScanFlags, timeout time.Duration) (matches []MatchRule, err error) {
-	cb := MatchRules{}
-	err = r.ScanFileDescriptorWithCallback(fd, flags, timeout, &cb)
-	matches = cb
-	return
-}
-
-// ScanFileDescriptorWithCallback scans a file using the ruleset. For every event
-// emitted by libyara, the appropriate method on the ScanCallback
+// ScanFileDescriptor scans a file using the ruleset. For every event
+// emitted by libyara, the corresponding method on the ScanCallback
 // object is called.
-func (r *Rules) ScanFileDescriptorWithCallback(fd uintptr, flags ScanFlags, timeout time.Duration, cb ScanCallback) (err error) {
+func (r *Rules) ScanFileDescriptor(fd uintptr, flags ScanFlags, timeout time.Duration, cb ScanCallback) (err error) {
 	id := callbackData.Put(makeScanCallbackContainer(cb))
 	defer callbackData.Delete(id)
 	err = newError(C._yr_rules_scan_fd(
@@ -167,19 +139,10 @@ func (r *Rules) ScanFileDescriptorWithCallback(fd uintptr, flags ScanFlags, time
 	return
 }
 
-// ScanProc scans a live process using the ruleset, returning matches
-// via a list of MatchRule objects.
-func (r *Rules) ScanProc(pid int, flags ScanFlags, timeout time.Duration) (matches []MatchRule, err error) {
-	cb := MatchRules{}
-	err = r.ScanProcWithCallback(pid, flags, timeout, &cb)
-	matches = cb
-	return
-}
-
-// ScanProcWithCallback scans a live process using the ruleset.  For
-// every event emitted by libyara, the appropriate method on the
+// ScanProc scans a live process using the ruleset.  For
+// every event emitted by libyara, the corresponding method on the
 // ScanCallback object is called.
-func (r *Rules) ScanProcWithCallback(pid int, flags ScanFlags, timeout time.Duration, cb ScanCallback) (err error) {
+func (r *Rules) ScanProc(pid int, flags ScanFlags, timeout time.Duration, cb ScanCallback) (err error) {
 	id := callbackData.Put(makeScanCallbackContainer(cb))
 	defer callbackData.Delete(id)
 	err = newError(C.yr_rules_scan_proc(
@@ -193,19 +156,10 @@ func (r *Rules) ScanProcWithCallback(pid int, flags ScanFlags, timeout time.Dura
 	return
 }
 
-// ScahMemBlocks scans over a MemoryBlockIterator using the ruleset,
-// returning matches via a list of MatchRule objects..
-func (r *Rules) ScanMemBlocks(mbi MemoryBlockIterator, flags ScanFlags, timeout time.Duration) (matches []MatchRule, err error) {
-	cb := MatchRules{}
-	err = r.ScanMemBlocksWithCallback(mbi, flags, timeout, &cb)
-	matches = cb
-	return
-}
-
-// ScanMemBlocksWithCallback scans over a MemoryBlockIterator using
-// the ruleset. For every event emitted by libyara, the appropriate
-// method on the ScanCallback object is called.
-func (r *Rules) ScanMemBlocksWithCallback(mbi MemoryBlockIterator, flags ScanFlags, timeout time.Duration, cb ScanCallback) (err error) {
+// ScanMemBlocks scans over a MemoryBlockIterator using the ruleset.
+// For every event emitted by libyara, the corresponding method on the
+// ScanCallback object is called.
+func (r *Rules) ScanMemBlocks(mbi MemoryBlockIterator, flags ScanFlags, timeout time.Duration, cb ScanCallback) (err error) {
 	c := makeMemoryBlockIteratorContainer(mbi)
 	defer c.free()
 	cmbi := makeCMemoryBlockIterator(c)

--- a/rules_callback.go
+++ b/rules_callback.go
@@ -27,7 +27,7 @@ type ScanContext struct {
 
 // ScanCallback is a placeholder for different interfaces that may be
 // implemented by the callback object that is passed to the
-// (*Rules).Scan*WithCallback and (*Scanner).Scan methods.
+// (*Rules).ScanXxxx and (*Scanner).ScanXxxx methods.
 //
 // The RuleMatching method corresponds to YARA's
 // CALLBACK_MSG_RULE_MATCHING message.

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -36,20 +36,13 @@ func makeScanner(t *testing.T, rule string) *Scanner {
 func TestScannerSimpleMatch(t *testing.T) {
 	s := makeScanner(t,
 		"rule test : tag1 { meta: author = \"Matt Blewitt\" strings: $a = \"abc\" fullword condition: $a }")
-	var m1, m2 MatchRules
-	var err error
-	if m1, err = s.ScanMem([]byte(" abc ")); err != nil {
+	var m MatchRules
+	if err := s.SetCallback(&m).ScanMem([]byte(" abc ")); err != nil {
 		t.Errorf("ScanMem: %s", err)
-	} else if len(m1) != 1 {
-		t.Errorf("ScanMem: wanted 1 match, got %d", len(m1))
+	} else if len(m) != 1 {
+		t.Errorf("ScanMem: wanted 1 match, got %d", len(m))
 	}
-	t.Logf("Matches: %+v", m1)
-	if _, err = s.SetCallback(&m2).ScanMem([]byte(" abc ")); err != nil {
-		t.Errorf("ScanMem: %s", err)
-	} else if len(m2) != 1 {
-		t.Errorf("ScanMem: wanted 1 match, got %d", len(m2))
-	}
-	t.Logf("Matches: %+v", m2)
+	t.Logf("Matches: %+v", m)
 }
 
 func TestScannerSimpleFileMatch(t *testing.T) {
@@ -59,20 +52,13 @@ func TestScannerSimpleFileMatch(t *testing.T) {
 	defer os.Remove(tf.Name())
 	tf.Write([]byte(" abc "))
 	tf.Close()
-	var m1, m2 MatchRules
-	var err error
-	if m1, err = s.ScanFile(tf.Name()); err != nil {
+	var m MatchRules
+	if err := s.SetCallback(&m).ScanFile(tf.Name()); err != nil {
 		t.Errorf("ScanFile(%s): %s", tf.Name(), err)
-	} else if len(m1) != 1 {
-		t.Errorf("ScanFile: wanted 1 match, got %d", len(m1))
+	} else if len(m) != 1 {
+		t.Errorf("ScanFile: wanted 1 match, got %d", len(m))
 	}
-	t.Logf("Matches: %+v", m1)
-	if _, err = s.SetCallback(&m2).ScanFile(tf.Name()); err != nil {
-		t.Errorf("ScanFile(%s): %s", tf.Name(), err)
-	} else if len(m2) != 1 {
-		t.Errorf("ScanFile: wanted 1 match, got %d", len(m2))
-	}
-	t.Logf("Matches: %+v", m2)
+	t.Logf("Matches: %+v", m)
 }
 
 func TestScannerSimpleFileDescriptorMatch(t *testing.T) {
@@ -82,20 +68,26 @@ func TestScannerSimpleFileDescriptorMatch(t *testing.T) {
 	defer os.Remove(tf.Name())
 	tf.Write([]byte(" abc "))
 	tf.Seek(0, os.SEEK_SET)
-	var m1, m2 MatchRules
-	var err error
-	if m1, err = s.ScanFileDescriptor(tf.Fd()); err != nil {
+	var m MatchRules
+	if err := s.SetCallback(&m).ScanFileDescriptor(tf.Fd()); err != nil {
 		t.Errorf("ScanFileDescriptor(%v): %s", tf.Fd(), err)
-	} else if len(m1) != 1 {
-		t.Errorf("ScanFileDescriptor: wanted 1 match, got %d", len(m1))
+	} else if len(m) != 1 {
+		t.Errorf("ScanFileDescriptor: wanted 1 match, got %d", len(m))
 	}
-	t.Logf("Matches: %+v", m1)
-	if _, err = s.SetCallback(&m2).ScanFileDescriptor(tf.Fd()); err != nil {
-		t.Errorf("ScanFileDescriptor(%v): %s", tf.Fd(), err)
-	} else if len(m2) != 1 {
-		t.Errorf("ScanFileDescriptor: wanted 1 match, got %d", len(m2))
+	t.Logf("Matches: %+v", m)
+}
+
+func TestScannerEmptyCallback(t *testing.T) {
+	s := makeScanner(t,
+		"rule test : tag1 { meta: author = \"Matt Blewitt\" strings: $a = \"abc\" fullword condition: $a }")
+	if err := s.ScanMem([]byte(" abc ")); err != nil {
+		t.Errorf("ScanMem: %s", err)
 	}
-	t.Logf("Matches: %+v", m2)
+	if m, ok := s.Callback.(*MatchRules); !ok {
+		t.Error("no *MatchRules set")
+	} else if len(*m) != 1 {
+		t.Errorf("length of MatchRules: %d  (expected 1)", len(*m))
+	}
 }
 
 // TestScannerIndependence tests that two scanners can
@@ -144,11 +136,11 @@ func TestScannerIndependence(t *testing.T) {
 	s2.DefineVariable("str_var", "bar")
 
 	var m1, m2 MatchRules
-	if _, err := s1.SetCallback(&m1).ScanMem([]byte("")); err != nil {
+	if err := s1.SetCallback(&m1).ScanMem([]byte("")); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := s2.SetCallback(&m2).ScanMem([]byte("")); err != nil {
+	if err := s2.SetCallback(&m2).ScanMem([]byte("")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -174,7 +166,7 @@ func TestScannerImportDataCallback(t *testing.T) {
 		rule t3 {
 			condition: tests.module_data == "callback-data-for-tests-module"
 		}`)
-	if _, err := s.SetCallback(cb).ScanMem([]byte("")); err != nil {
+	if err := s.SetCallback(cb).ScanMem([]byte("")); err != nil {
 		t.Error(err)
 	}
 	for _, module := range []string{"tests", "pe"} {
@@ -203,7 +195,7 @@ func TestScannerLastError(t *testing.T) {
 	// Repeat future match (YR_MAX_STRING_MATCHES + 1) times
 	buffer := bytes.Repeat([]byte(" abc "), 1000000+1)
 	var err error
-	if _, err = s.ScanMem(buffer); err == nil {
+	if err = s.ScanMem(buffer); err == nil {
 		t.Fatal("ScanMem: did not fail")
 	}
 	t.Logf("ScanMem: got expected error, %s", err)

--- a/stress_test.go
+++ b/stress_test.go
@@ -53,7 +53,8 @@ func TestFileWalk(t *testing.T) {
 				}
 				// r.DefineVariable("filename", info.Name())
 				// r.DefineVariable("filepath", name)
-				if m, err := r.ScanFile(name, 0, 0); err == nil {
+				var m MatchRules
+				if err := r.ScanFile(name, 0, 0, &m); err == nil {
 					fmt.Printf("[%02d] Scan \"%s\": %d\n", i, path.Base(name), len(m))
 				} else {
 					fmt.Printf("[%02d] Scan \"%s\": %s\n", i, path.Base(name), err)
@@ -121,7 +122,7 @@ func TestScannerFileWalk(t *testing.T) {
 				s.DefineVariable("filepath", name)
 				s.DefineVariable("filename", info.Name())
 				var m MatchRules
-				if _, err := s.SetCallback(&m).ScanFile(name); err == nil {
+				if err := s.SetCallback(&m).ScanFile(name); err == nil {
 					fmt.Printf("[%02d] Scan \"%s\": %d\n", i, path.Base(name), len(m))
 				} else {
 					fmt.Printf("[%02d] Scan \"%s\": %s\n", i, path.Base(name), err)


### PR DESCRIPTION
I intend to make a few changes to the API before tagging/releasing go-yara 4.0 in the next 1-2 weeks and am looking for comments from users of go-yara.

So far those breaking changes are:
- Re-unite `(*Rules).ScanXxxx` with `(*Rules).ScanXxxxCallback` methods
- Represent a `Rule`'s metavariables as a list; remove all map representations (leftover from #44)