### PR TITLE
Fix bug where no rules seemed to occur in ruleset

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -284,8 +284,8 @@ func (r *Rules) GetRules() (rv []Rule) {
 	// #define yr_rules_foreach(rules, rule) \
 	//     for (rule = rules->rules_list_head; !RULE_IS_NULL(rule); rule++)
 	// #define RULE_IS_NULL(x) \
-	//     (((x)->g_flags) & RULE_GFLAGS_NULL)
-	for p := r.cptr.rules_list_head; p.flags&C.RULE_FLAGS_NULL != 0; p = (*C.YR_RULE)(unsafe.Pointer(uintptr(unsafe.Pointer(p)) + unsafe.Sizeof(*p))) {
+	//     (((x)->flags) & RULE_FLAGS_NULL)
+	for p := r.cptr.rules_list_head; p.flags&C.RULE_FLAGS_NULL == 0; p = (*C.YR_RULE)(unsafe.Pointer(uintptr(unsafe.Pointer(p)) + unsafe.Sizeof(*p))) {
 		rv = append(rv, Rule{(*C.YR_RULE)(p)})
 	}
 	return

--- a/rules_test.go
+++ b/rules_test.go
@@ -218,6 +218,9 @@ func TestRule(t *testing.T) {
 		rule t4 { strings: $d = "qwe" condition: $d }
 		private rule t5 { condition: false }
 		global rule t6 { condition: false }`)
+	if len(r.GetRules()) != 6 {
+		t.Error("Number of generated rules was incorrect")
+	}
 	for _, r := range r.GetRules() {
 		t.Logf("%s:%s %#v", r.Namespace(), r.Identifier(), r.Tags())
 		switch r.Identifier() {
@@ -225,29 +228,29 @@ func TestRule(t *testing.T) {
 			if !reflect.DeepEqual(r.Tags(), []string{"tag1"}) {
 				t.Error("Got wrong tags for t1")
 			}
-			if !reflect.DeepEqual(r.Metas(), Meta{"author", "Author One"}) {
+			if !reflect.DeepEqual(r.Metas(), []Meta{Meta{"author", "Author One"}}) {
 				t.Error("Got wrong meta variables for t1")
 			}
 		case "t2":
 			if !reflect.DeepEqual(r.Tags(), []string{"tag2", "x", "y"}) {
 				t.Error("Got wrong tags for t2")
 			}
-			if !reflect.DeepEqual(r.Metas(), Meta{"author", "Author Two"}) {
+			if !reflect.DeepEqual(r.Metas(), []Meta{Meta{"author", "Author Two"}}) {
 				t.Error("Got wrong meta variables for t2")
 			}
 		case "t3":
 			if !reflect.DeepEqual(r.Tags(), []string{"tag3", "x", "y", "z"}) {
 				t.Error("Got wrong tags for t3")
 			}
-			if !reflect.DeepEqual(r.Metas(), Meta{"author", "Author Three"}) {
+			if !reflect.DeepEqual(r.Metas(), []Meta{Meta{"author", "Author Three"}}) {
 				t.Error("Got wrong meta variables for t3")
 			}
 		case "t4":
 			if len(r.Tags()) != 0 {
 				t.Error("Got tags for t4")
 			}
-			if !reflect.DeepEqual(r.Metas(), Meta{}) {
-				t.Error("Got wrong meta variables for t4")
+			if len(r.Metas()) != 0 {
+				t.Error("Got meta variables for t4")
 			}
 			if r.IsPrivate() {
 				t.Error("Rule t5 is not supposed to be private!")


### PR DESCRIPTION
Correct an error where the check whether the null flag was set for
a rule was inverted.
Also adjust the tests to properly check for the number of rules
that are returned.