### PR TITLE
Cross-build documentation: Fix paths, add Windows/MSYS2 build

### DIFF
--- a/README.cross-building.md
+++ b/README.cross-building.md
@@ -12,14 +12,19 @@ variables need to be set when running `go build` or `go install`:
 - `GOOS`, `GOARCH` indicate the cross compilation target.
 - `CGO_ENABLED` has to be set to 1 beacuse it defaults to 0 when
   cross-compiling.
-- `CC` has to be set to the C cross compiler. (It defaults to the
-  system C compiler, usually gcc).
-- `PKG_CONFIG_PATH` has to be set to the _pkg-config_ directory where
-  the `yara.pc` file has been installed. (Alternatively, the
-  `yara_no_pkg_config` build tag can be used togethere with
-  `CGO_CFLAGS` and `CGO_LDFLAGS` environment variables.)
+- `CC` may have to be set to point to the C cross compiler. (It
+  defaults to the system C compiler, usually gcc).
+- `PKG_CONFIG_PATH` may have to be set to point to the _pkg-config_
+  directory where the `yara.pc` file has been
+  installed. (Alternatively, the `yara_no_pkg_config` build tag can be
+  used together with `CGO_CFLAGS` and `CGO_LDFLAGS` environment
+  variables.)
 
-## Example: Building an entirely static Linux binary
+Since the MinGW environments provided by [MSYS2](https://msys2.org/)
+are technically cross-building environments, similar steps have to be
+taken, see below.
+
+## Example: Building an entirely static Linux binary (musl-libc)
 
 Because binaries that are linked statically with GNU libc are not
 entirely portable [musl libc](https://www.musl-libc.org/) can be used
@@ -37,7 +42,7 @@ make -C ${YARA_BUILD_LINUX_MUSL} install
 GOOS=linux GOARCH=amd64 CGO_ENABLED=1 \
   CC=musl-gcc \
   PKG_CONFIG_PATH=${PREFIX_LINUX_MUSL}/lib/pkgconfig \
-      go build -ldflags '-extldflags "-static"' -o simple-yara-musl simple-yara.go
+      go build -ldflags '-extldflags "-static"' -tags yara_static -o simple-yara-musl ./_examples/simple-yara
 ```
 
 ## Example: Cross-building for Windows
@@ -55,7 +60,7 @@ make -C ${YARA_BUILD_WIN32} install
 GOOS=windows GOARCH=386 CGO_ENABLED=1 \
   CC=i686-w64-mingw32-gcc \
   PKG_CONFIG_PATH=${PREFIX_WIN32}/lib/pkgconfig \
-      go build -ldflags '-extldflags "-static"' -o simple-yara-w32.exe simple-yara.go
+      go build -ldflags '-extldflags "-static"' -tags yara_static -o simple-yara-w32.exe ./_examples/simple-yara
 ```
 
 Build _libyara_ and [`_examples/simple-yara`](_examples/simple-yara) for Win64:
@@ -67,5 +72,49 @@ make -C ${YARA_BUILD_WIN64} install
 GOOS=windows GOARCH=amd64 CGO_ENABLED=1 \
   CC=x86_64-w64-mingw32-gcc \
   PKG_CONFIG_PATH=${PREFIX_WIN64}/lib/pkgconfig \
-      go build -ldflags '-extldflags "-static"' -o simple-yara-w64.exe simple-yara.go
+      go build -ldflags '-extldflags "-static"' -tags yara_static -o simple-yara-w64.exe ./_examples/simple-yara
 ```
+
+## Example: Building on Windows, using MSYS2
+
+This example assumes that [MSYS2](https://msys2.org/) has been
+installed to `C:\msys64`. The following packages have to be installed:
+- autoconf
+- automake
+- libtool
+- mingw-w64-{x86_64,i686}-gcc
+- mingw-w64-{x86_64,i686}-make
+- mingw-w64-{x86_64,i686}-pkgconf
+
+While MSYS2 contains usable Go compilers, the [official
+distribution](https://golang.org/dl) is used here.
+
+Build _libyara_ and [`_examples/simple-yara`](_examples/simple-yara) for Win32:
+
+- At the MinGW 32 prompt:
+  ```
+  cd ${YARA_BUILD_WIN32} && ${YARA_SRC}/configure
+  make -C ${YARA_BUILD_WIN32} install
+  ```
+- At the CMD or Powershell prompt:
+  ```
+  set PATH=%PATH%;C:\msys64\mingw32\bin
+  set CGO_ENABLED=1
+  set GOARCH=386
+  go build -ldflags "-extldflags=-static" -tags yara_static -o simple-yara-w32.exe .\_examples\simple-yara
+  ```
+
+Build _libyara_ and [`_examples/simple-yara`](_examples/simple-yara) for Win64:
+
+- At the MinGW 64 prompt:
+  ```
+  cd ${YARA_BUILD_WIN64} && ${YARA_SRC}/configure
+  make -C ${YARA_BUILD_WIN64} install
+  ```
+- At the CMD or Powershell prompt:
+  ```
+  set PATH=%PATH%;C:\msys64\mingw64\bin
+  set CGO_ENABLED=1
+  set GOARCH=amd64
+  go build -ldflags "-extldflags=-static" -tags yara_static -o simple-yara-w64.exe .\_examples\simple-yara
+  ```

--- a/README.md
+++ b/README.md
@@ -12,22 +12,15 @@ the `yara-python` implementation.
 
 ## Build/Installation
 
-On y Unix system, _libyara_ version 4, corresponding header files, and
-_pkg-config_ must be installed. Adding _go-yara_ v4 to a project with
-Go Modules enabled, simply add the proper dependency…
+On Unix-like systems, _libyara_ version 4, corresponding header files,
+and _pkg-config_ must be installed. Adding _go-yara_ v4 to a project
+with Go Modules enabled, simply add the proper dependency…
 
 ``` go
 import "github.com/hillu/go-yara/v4"
 ```
 
 …and rebuild your package.
-
-To install _go-yara_ v4 to GOPATH, do:
-
-```
-go get github.com/hillu/go-yara/v4
-go install github.com/hillu/go-yara/v4
-```
 
 If _libyara_ has been installed to a custom location, the
 `PKG_CONFIG_PATH` environment variable can be used to point
@@ -37,6 +30,11 @@ For anything more complicated, refer to the "Build Tags" section
 below. Instructions for cross-building _go-yara_ for different
 operating systems or architectures can be found in
 [README.cross-building.md](README.cross-building.md).
+
+To build _go-yara_ on Windows, a GCC-based build environment is
+required, preferably one that includes _pkg-config_. The 32-bit and
+64-bit MinGW environments provided by the [MSYS2](https://msys2.org/)
+provide such an environment.
 
 ## Build Tags
 


### PR DESCRIPTION
The Windows/MSYS2 build instructions are loosely based on #79.