### PR TITLE
fix: use malloc'd locations to store cgo handles

### DIFF
--- a/handle.go
+++ b/handle.go
@@ -1,15 +1,40 @@
-//+build go1.17
+//go:build go1.17
+// +build go1.17
 
 // This variant contains a trivial wrapper around "runtime/cgo".Handle.
 
 package yara
 
-import "runtime/cgo"
+import (
+	"runtime/cgo"
+	"unsafe"
+)
+
+// #include <stdlib.h>
+import "C"
 
 type cgoHandle cgo.Handle
 
-func (h cgoHandle) Value() interface{} { return cgo.Handle(h).Value() }
+func (h *cgoHandle) Value() interface{} {
+	return cgo.Handle(*h).Value()
+}
 
-func (h cgoHandle) Delete() { cgo.Handle(h).Delete() }
+func (h *cgoHandle) Delete() {
+	cgo.Handle(*h).Delete()
+	C.free(unsafe.Pointer(h))
+}
 
-func cgoNewHandle(v interface{}) cgoHandle { return cgoHandle(cgo.NewHandle(v)) }
+func newCgoHandle(v interface{}) *cgoHandle {
+	handle := cgo.NewHandle(v)
+	pointer := C.malloc(C.ulong(unsafe.Sizeof(handle)))
+	*((*uintptr)(pointer)) = uintptr(handle)
+	return (*cgoHandle)(pointer)
+}
+
+func loadCgoHandle(pointer unsafe.Pointer) *cgoHandle {
+	return (*cgoHandle)(pointer)
+}
+
+func (h *cgoHandle) Pointer() unsafe.Pointer {
+	return (unsafe.Pointer)(h)
+}

--- a/handle_legacy.go
+++ b/handle_legacy.go
@@ -1,39 +1,55 @@
-//+build !go1.17
+//go:build !go1.17
+// +build !go1.17
 
-// This variant contains a backport of go 1.18's "runtime/cgo".Handle.
+// This variant contains a modified backport of go 1.18's "runtime/cgo".Handle that returns valid, CGO allocated pointers.
 
 package yara
 
 import (
 	"sync"
 	"sync/atomic"
+	"unsafe"
 )
+
+// #include <stdlib.h>
+import "C"
 
 type cgoHandle uintptr
 
-func cgoNewHandle(v interface{}) cgoHandle {
-	h := atomic.AddUintptr(&handleIdx, 1)
-	if h == 0 {
-		panic("cgoNewHandle: ran out of handle space")
+func newCgoHandle(v interface{}) *cgoHandle {
+	handle := atomic.AddUintptr(&handleIdx, 1)
+	if handle == 0 {
+		panic("newCgoHandle: ran out of handle space")
 	}
 
-	handles.Store(h, v)
-	return cgoHandle(h)
+	handles.Store(handle, v)
+	pointer := C.malloc(C.ulong(unsafe.Sizeof(handle)))
+	*((*uintptr)(pointer)) = handle
+	return (*cgoHandle)(pointer)
 }
 
-func (h cgoHandle) Value() interface{} {
-	v, ok := handles.Load(uintptr(h))
+func (h *cgoHandle) Value() interface{} {
+	v, ok := handles.Load(uintptr(*h))
 	if !ok {
 		panic("cgoHandle: misuse of an invalid Handle")
 	}
 	return v
 }
 
-func (h cgoHandle) Delete() {
-	_, ok := handles.LoadAndDelete(uintptr(h))
+func (h *cgoHandle) Delete() {
+	_, ok := handles.LoadAndDelete(uintptr(*h))
 	if !ok {
 		panic("cgoHandle: misuse of an invalid Handle")
 	}
+	C.free(unsafe.Pointer(h))
+}
+
+func loadCgoHandle(pointer unsafe.Pointer) *cgoHandle {
+	return (*cgoHandle)(pointer)
+}
+
+func (h *cgoHandle) Pointer() unsafe.Pointer {
+	return (unsafe.Pointer)(h)
 }
 
 var (

--- a/mem_blocks.go
+++ b/mem_blocks.go
@@ -65,7 +65,7 @@ func makeMemoryBlockIteratorContainer(mbi MemoryBlockIterator) (c *memoryBlockIt
 // The caller is responsible to delete the cgoHandle cmbi.context.
 func makeCMemoryBlockIterator(c *memoryBlockIteratorContainer) (cmbi *C.YR_MEMORY_BLOCK_ITERATOR) {
 	cmbi = &C.YR_MEMORY_BLOCK_ITERATOR{
-		context: unsafe.Pointer(cgoNewHandle(c)),
+		context: newCgoHandle(c).Pointer(),
 		first:   C.YR_MEMORY_BLOCK_ITERATOR_FUNC(C.memoryBlockIteratorFirst),
 		next:    C.YR_MEMORY_BLOCK_ITERATOR_FUNC(C.memoryBlockIteratorNext),
 	}
@@ -108,7 +108,7 @@ type MemoryBlock struct {
 //
 //export memoryBlockFetch
 func memoryBlockFetch(cblock *C.YR_MEMORY_BLOCK) *C.uint8_t {
-	c := cgoHandle(cblock.context).Value().(*memoryBlockIteratorContainer)
+	c := loadCgoHandle(cblock.context).Value().(*memoryBlockIteratorContainer)
 	c.realloc(int(cblock.size))
 	c.MemoryBlock.FetchData(c.buf)
 	return (*C.uint8_t)(unsafe.Pointer(&c.buf[0]))
@@ -143,7 +143,7 @@ func memoryBlockIteratorCommon(cmbi *C.YR_MEMORY_BLOCK_ITERATOR, c *memoryBlockI
 //
 //export memoryBlockIteratorFirst
 func memoryBlockIteratorFirst(cmbi *C.YR_MEMORY_BLOCK_ITERATOR) *C.YR_MEMORY_BLOCK {
-	c := cgoHandle(cmbi.context).Value().(*memoryBlockIteratorContainer)
+	c := loadCgoHandle(cmbi.context).Value().(*memoryBlockIteratorContainer)
 	c.MemoryBlock = c.MemoryBlockIterator.First()
 	return memoryBlockIteratorCommon(cmbi, c)
 }
@@ -153,13 +153,13 @@ func memoryBlockIteratorFirst(cmbi *C.YR_MEMORY_BLOCK_ITERATOR) *C.YR_MEMORY_BLO
 //
 //export memoryBlockIteratorNext
 func memoryBlockIteratorNext(cmbi *C.YR_MEMORY_BLOCK_ITERATOR) *C.YR_MEMORY_BLOCK {
-	c := cgoHandle(cmbi.context).Value().(*memoryBlockIteratorContainer)
+	c := loadCgoHandle(cmbi.context).Value().(*memoryBlockIteratorContainer)
 	c.MemoryBlock = c.MemoryBlockIterator.Next()
 	return memoryBlockIteratorCommon(cmbi, c)
 }
 
 //export memoryBlockIteratorFilesize
 func memoryBlockIteratorFilesize(cmbi *C.YR_MEMORY_BLOCK_ITERATOR) C.uint64_t {
-	c := cgoHandle(cmbi.context).Value().(*memoryBlockIteratorContainer)
+	c := loadCgoHandle(cmbi.context).Value().(*memoryBlockIteratorContainer)
 	return C.uint64_t(c.MemoryBlockIterator.(MemoryBlockIteratorWithFilesize).Filesize())
 }

--- a/rules_callback.go
+++ b/rules_callback.go
@@ -103,7 +103,7 @@ func (c *scanCallbackContainer) finalize() {
 
 //export scanCallbackFunc
 func scanCallbackFunc(ctx *C.YR_SCAN_CONTEXT, message C.int, messageData, userData unsafe.Pointer) C.int {
-	cbc, ok := cgoHandle(userData).Value().(*scanCallbackContainer)
+	cbc, ok := loadCgoHandle(userData).Value().(*scanCallbackContainer)
 	s := &ScanContext{cptr: ctx}
 	if !ok {
 		return C.CALLBACK_ERROR

--- a/scanner.go
+++ b/scanner.go
@@ -119,11 +119,11 @@ func (s *Scanner) SetCallback(cb ScanCallback) *Scanner {
 // a cgoHandle. If no callback object has been
 // set, it is initialized with the pointer to an empty ScanRules
 // object. The handle must be deleted by the calling ScanXxxx function.
-func (s *Scanner) putCallbackData() cgoHandle {
+func (s *Scanner) putCallbackData() *cgoHandle {
 	if _, ok := s.Callback.(ScanCallback); !ok {
 		s.Callback = &MatchRules{}
 	}
-	ptr := cgoNewHandle(makeScanCallbackContainer(s.Callback, s.rules))
+	ptr := newCgoHandle(makeScanCallbackContainer(s.Callback, s.rules))
 	C.yr_scanner_set_callback(s.cptr, C.YR_CALLBACK_FUNC(C.scanCallbackFunc), unsafe.Pointer(ptr))
 	return ptr
 }
@@ -212,7 +212,7 @@ func (s *Scanner) ScanMemBlocks(mbi MemoryBlockIterator) (err error) {
 	c := makeMemoryBlockIteratorContainer(mbi)
 	defer c.free()
 	cmbi := makeCMemoryBlockIterator(c)
-	defer cgoHandle(cmbi.context).Delete()
+	defer loadCgoHandle(cmbi.context).Delete()
 
 	cbPtr := s.putCallbackData()
 	defer cbPtr.Delete()

--- a/stream.go
+++ b/stream.go
@@ -20,7 +20,7 @@ func streamRead(ptr unsafe.Pointer, size, nmemb C.size_t, userData unsafe.Pointe
 	if size == 0 || nmemb == 0 {
 		return nmemb
 	}
-	reader := cgoHandle(userData).Value().(io.Reader)
+	reader := loadCgoHandle(userData).Value().(io.Reader)
 	buf := make([]byte, 0)
 	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&buf))
 	hdr.Data = uintptr(ptr)
@@ -53,7 +53,7 @@ func streamWrite(ptr unsafe.Pointer, size, nmemb C.size_t, userData unsafe.Point
 	if size == 0 || nmemb == 0 {
 		return nmemb
 	}
-	writer := cgoHandle(userData).Value().(io.Writer)
+	writer := loadCgoHandle(userData).Value().(io.Writer)
 	buf := make([]byte, 0)
 	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&buf))
 	hdr.Data = uintptr(ptr)


### PR DESCRIPTION
Implementation of the malloc/free solution that was proposed for #101, 