### PR TITLE
fix: also malloc user data pointer in memory iterator

### DIFF
--- a/mem_blocks.go
+++ b/mem_blocks.go
@@ -62,10 +62,12 @@ func makeMemoryBlockIteratorContainer(mbi MemoryBlockIterator) (c *memoryBlockIt
 	return
 }
 
-// The caller is responsible to delete the cgoHandle cmbi.context.
+// The caller is responsible to delete the cgoHandle *cmbi.context and free cmbi.context.
 func makeCMemoryBlockIterator(c *memoryBlockIteratorContainer) (cmbi *C.YR_MEMORY_BLOCK_ITERATOR) {
+	userData := (*cgoHandle)(C.malloc(C.size_t(unsafe.Sizeof(cgoHandle(0)))))
+	*userData = cgoNewHandle(c)
 	cmbi = &C.YR_MEMORY_BLOCK_ITERATOR{
-		context: unsafe.Pointer(cgoNewHandle(c)),
+		context: unsafe.Pointer(userData),
 		first:   C.YR_MEMORY_BLOCK_ITERATOR_FUNC(C.memoryBlockIteratorFirst),
 		next:    C.YR_MEMORY_BLOCK_ITERATOR_FUNC(C.memoryBlockIteratorNext),
 	}
@@ -108,7 +110,7 @@ type MemoryBlock struct {
 //
 //export memoryBlockFetch
 func memoryBlockFetch(cblock *C.YR_MEMORY_BLOCK) *C.uint8_t {
-	c := cgoHandle(cblock.context).Value().(*memoryBlockIteratorContainer)
+	c := ((*cgoHandle)(cblock.context)).Value().(*memoryBlockIteratorContainer)
 	c.realloc(int(cblock.size))
 	c.MemoryBlock.FetchData(c.buf)
 	return (*C.uint8_t)(unsafe.Pointer(&c.buf[0]))
@@ -143,7 +145,7 @@ func memoryBlockIteratorCommon(cmbi *C.YR_MEMORY_BLOCK_ITERATOR, c *memoryBlockI
 //
 //export memoryBlockIteratorFirst
 func memoryBlockIteratorFirst(cmbi *C.YR_MEMORY_BLOCK_ITERATOR) *C.YR_MEMORY_BLOCK {
-	c := cgoHandle(cmbi.context).Value().(*memoryBlockIteratorContainer)
+	c := ((*cgoHandle)(cmbi.context)).Value().(*memoryBlockIteratorContainer)
 	c.MemoryBlock = c.MemoryBlockIterator.First()
 	return memoryBlockIteratorCommon(cmbi, c)
 }
@@ -153,13 +155,13 @@ func memoryBlockIteratorFirst(cmbi *C.YR_MEMORY_BLOCK_ITERATOR) *C.YR_MEMORY_BLO
 //
 //export memoryBlockIteratorNext
 func memoryBlockIteratorNext(cmbi *C.YR_MEMORY_BLOCK_ITERATOR) *C.YR_MEMORY_BLOCK {
-	c := cgoHandle(cmbi.context).Value().(*memoryBlockIteratorContainer)
+	c := ((*cgoHandle)(cmbi.context)).Value().(*memoryBlockIteratorContainer)
 	c.MemoryBlock = c.MemoryBlockIterator.Next()
 	return memoryBlockIteratorCommon(cmbi, c)
 }
 
 //export memoryBlockIteratorFilesize
 func memoryBlockIteratorFilesize(cmbi *C.YR_MEMORY_BLOCK_ITERATOR) C.uint64_t {
-	c := cgoHandle(cmbi.context).Value().(*memoryBlockIteratorContainer)
+	c := ((*cgoHandle)(cmbi.context)).Value().(*memoryBlockIteratorContainer)
 	return C.uint64_t(c.MemoryBlockIterator.(MemoryBlockIteratorWithFilesize).Filesize())
 }

--- a/rules.go
+++ b/rules.go
@@ -152,7 +152,8 @@ func (r *Rules) ScanMemBlocks(mbi MemoryBlockIterator, flags ScanFlags, timeout 
 	c := makeMemoryBlockIteratorContainer(mbi)
 	defer c.free()
 	cmbi := makeCMemoryBlockIterator(c)
-	defer cgoHandle(cmbi.context).Delete()
+	defer C.free(cmbi.context)
+	defer ((*cgoHandle)(cmbi.context)).Delete()
 	userData := cgoNewHandle(makeScanCallbackContainer(cb, r))
 	defer userData.Delete()
 	err = newError(C.yr_rules_scan_mem_blocks(

--- a/scanner.go
+++ b/scanner.go
@@ -214,7 +214,8 @@ func (s *Scanner) ScanMemBlocks(mbi MemoryBlockIterator) (err error) {
 	c := makeMemoryBlockIteratorContainer(mbi)
 	defer c.free()
 	cmbi := makeCMemoryBlockIterator(c)
-	defer cgoHandle(cmbi.context).Delete()
+	defer C.free(cmbi.context)
+	defer ((*cgoHandle)(cmbi.context)).Delete()
 	s.putCallbackData()
 	C.yr_scanner_set_flags(s.cptr, s.flags.withReportFlags(s.Callback))
 	err = newError(C.yr_scanner_scan_mem_blocks(


### PR DESCRIPTION
Fixes a potential issue where a fake-pointer was passed to CGO. 

This could cause issues in rare cases. To reproduce one of those: 
- enforce use of handle_legacy.go
- set handleIdx to a high starter value, e.g. 0xc001071340 (essentially simulating a high number of NewHandle() calls)
- repeatedly call ScanMemBlocks