### PR TITLE
fix: release callback data handle

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -62,6 +62,9 @@ func (s *Scanner) Destroy() {
 		s.cptr = nil
 	}
 	if s.userData != nil {
+		if *s.userData != 0 {
+			s.userData.Delete()
+		}
 		C.free(unsafe.Pointer(s.userData))
 		s.userData = nil
 	}


### PR DESCRIPTION
Scanner's userData was freed, but the underlying cgo.Handle was not deleted. This caused memory leaks since the resources connected to the handle were never garbage collected.