### PR TITLE
fix: free profiling info

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -267,7 +267,9 @@ type RuleProfilingInfo struct {
 
 // GetProfilingInfo retrieves profiling information from the Scanner.
 func (s *Scanner) GetProfilingInfo() (rpis []RuleProfilingInfo) {
-	for rpi := C.yr_scanner_get_profiling_info(s.cptr); rpi.rule != nil; rpi = (*C.YR_RULE_PROFILING_INFO)(unsafe.Pointer(uintptr(unsafe.Pointer(rpi)) + unsafe.Sizeof(*rpi))) {
+	rpi := C.yr_scanner_get_profiling_info(s.cptr)
+	defer C.yr_free(unsafe.Pointer(rpi))
+	for ; rpi.rule != nil; rpi = (*C.YR_RULE_PROFILING_INFO)(unsafe.Pointer(uintptr(unsafe.Pointer(rpi)) + unsafe.Sizeof(*rpi))) {
 		rpis = append(rpis, RuleProfilingInfo{Rule{rpi.rule, s.rules}, uint64(rpi.cost)})
 	}
 	return


### PR DESCRIPTION
According to the yr_scanner_get_profiling_info documentation (see the comment in scanner.c):

> The caller is responsible for freeing the returned array by calling yr_free.

This is not happening right now, causing a memory leak whenever GetProfilingInfo() is invoked.