### PR TITLE
fix: set SCAN_FLAGS_NO_TRYCATCH for memory block iterators

### DIFF
--- a/mem_blocks_test.go
+++ b/mem_blocks_test.go
@@ -93,3 +93,56 @@ condition: filesize >= 20
 		t.Logf("simple iterator scan (aaa..bbb): %+v", mrs)
 	}
 }
+
+type testPanicIter struct {
+	data    []block
+	current int
+}
+
+func (it *testPanicIter) First() *MemoryBlock {
+	it.current = 0
+	return it.Next()
+}
+
+func (it *testPanicIter) Next() *MemoryBlock {
+	if it.current >= len(it.data) {
+		return nil
+	}
+	data := it.data[it.current].data
+	base := it.data[it.current].base
+	it.current += 1
+	return &MemoryBlock{
+		Base: base,
+		Size: uint64(len(data)),
+		FetchData: func(buf []byte) {
+			// Simulate a caught panic during data fetch
+			func() {
+				defer func() {
+					recover() // Recover from panic
+				}()
+				// Cause a panic by writing to a nil pointer
+				var nilPointer *int
+				*nilPointer = 0
+			}()
+			copy(buf, data)
+		},
+	}
+}
+
+func TestIteratorWithPanic(t *testing.T) {
+	rs := MustCompile(`
+import "math"
+rule t1 { condition: math.entropy(0, 10) < 0.5 }
+`, nil)
+	var mrs MatchRules
+	if err := rs.ScanMemBlocks(&testPanicIter{
+		data: []block{
+			{0, []byte("aaaaaaaaaaaaaaaa")},
+			{32, []byte("bbbbbbbbbbbbbbbb")},
+		},
+	}, 0, 0, &mrs); err != nil {
+		t.Errorf("simple iterator scan (aaa..bbbb): %v", err)
+	} else {
+		t.Logf("simple iterator scan (aaa..bbb): %+v", mrs)
+	}
+}

--- a/rules.go
+++ b/rules.go
@@ -164,7 +164,7 @@ func (r *Rules) ScanMemBlocks(mbi MemoryBlockIterator, flags ScanFlags, timeout 
 	err = newError(C.yr_rules_scan_mem_blocks(
 		r.cptr,
 		cmbi,
-		flags.withReportFlags(cb),
+		flags.withReportFlags(cb)|C.SCAN_FLAGS_NO_TRYCATCH,
 		C.YR_CALLBACK_FUNC(C.scanCallbackFunc),
 		unsafe.Pointer(&userData),
 		C.int(timeout/time.Second)))

--- a/scanner.go
+++ b/scanner.go
@@ -217,7 +217,7 @@ func (s *Scanner) ScanProc(pid int) (err error) {
 // ScanMemBlocks scans over a MemoryBlockIterator using the scanner.
 //
 // If no callback object has been set for the scanner using
-// SetCAllback, it is initialized with an empty MatchRules object.
+// SetCallback, it is initialized with an empty MatchRules object.
 func (s *Scanner) ScanMemBlocks(mbi MemoryBlockIterator) (err error) {
 	c := makeMemoryBlockIteratorContainer(mbi)
 	defer c.free()
@@ -225,7 +225,7 @@ func (s *Scanner) ScanMemBlocks(mbi MemoryBlockIterator) (err error) {
 	defer C.free(cmbi.context)
 	defer ((*cgoHandle)(cmbi.context)).Delete()
 	s.putCallbackData()
-	C.yr_scanner_set_flags(s.cptr, s.flags.withReportFlags(s.Callback))
+	C.yr_scanner_set_flags(s.cptr, s.flags.withReportFlags(s.Callback)|C.SCAN_FLAGS_NO_TRYCATCH)
 	err = newError(C.yr_scanner_scan_mem_blocks(
 		s.cptr,
 		cmbi,


### PR DESCRIPTION
When using memory block iterators, callbacks to golang code can occur while the YARA signal handler is set.
If the golang callback causes a SIGSEGV / SIGBUS (e.g. as a panic), this causes a runtime fault instead of executing pending defer() calls and potentially recovering: the code execution jumps back to YARA without notifying the golang runtime, and the runtime faults with "exitsyscall: syscall frame is no longer valid"
after yr_scanner_scan_mem_blocks returns.

To avoid these scenarios, always set SCAN_FLAGS_NO_TRYCATCH on memory block iterators. Doing so prevents YARA from installing its own signal handler, which is superfluous in this case anyway since we read the data in Golang, and should take care of any signals while reading the data ourselves.