### PR TITLE
Ordering configuration options ConfigMaxMatchData and ConfigMaxStringsPerRule 

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,8 +14,8 @@ type ConfigName uint32
 
 const (
 	ConfigStackSize             ConfigName = C.YR_CONFIG_STACK_SIZE
-	ConfigMaxMatchData                     = C.YR_CONFIG_MAX_MATCH_DATA
 	ConfigMaxStringsPerRule                = C.YR_CONFIG_MAX_STRINGS_PER_RULE
+	ConfigMaxMatchData                     = C.YR_CONFIG_MAX_MATCH_DATA
 	ConfigMaxProcessMemoryChunk            = C.YR_CONFIG_MAX_PROCESS_MEMORY_CHUNK
 )
 


### PR DESCRIPTION
The order of configuration options found in `config.go`:
https://github.com/hillu/go-yara/blob/11d1088a1ff305f3d292f73e31db195b8ce40028/config.go#L16-L19

Did not match the order of configuration options in `libyara.h`:
https://github.com/VirusTotal/yara/blob/8ce0c6c4eb38672cd09c51d5fca4d1ce22e9746c/libyara/include/yara/libyara.h#L70-L84

The following code gets and sets yara configuration options in the order found in `libyara.h` rather than the order found in `config.go`:
```go
package main

import (
	"fmt"

	"github.com/hillu/go-yara/v4"
)

func main() {
	fmt.Println(yara.GetConfiguration(0))
	fmt.Println(yara.GetConfiguration(1))
	fmt.Println(yara.GetConfiguration(2))
	fmt.Println(yara.GetConfiguration(3))
	yara.SetConfiguration(0, 0)
	yara.SetConfiguration(1, 1)
	yara.SetConfiguration(2, 2)
	yara.SetConfiguration(3, 3)
	fmt.Println(yara.GetConfiguration(0))
	fmt.Println(yara.GetConfiguration(1))
	fmt.Println(yara.GetConfiguration(2))
	fmt.Println(yara.GetConfiguration(3))
}
```
---
```shell
16384 <nil>
10000 <nil>
512 <nil>
1073741824 <nil>
0 <nil>
1 <nil>
2 <nil>
3 <nil>
```

This PR orders the configuration options to match the order found in `libyara.h`