### PR TITLE
Enhance the `Error` type to provide more information about the error.

### DIFF
--- a/compiler_test.go
+++ b/compiler_test.go
@@ -6,7 +6,9 @@
 
 package yara
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestCompiler(t *testing.T) {
 	c, _ := NewCompiler()
@@ -41,6 +43,18 @@ func TestWarnings(t *testing.T) {
 		t.Error()
 	}
 	t.Logf("Recorded Errors=%#v, Warnings=%#v", c.Errors, c.Warnings)
+}
+
+func TestErrors(t *testing.T) {
+	c, _ := NewCompiler()
+	c.AddString("rule foo { bar }", "")
+	if len(c.Errors) == 0 {
+		t.Error("did not recognize error")
+	}
+	expectedError := "rule \"foo\": syntax error, unexpected identifier, expecting <condition>"
+	if c.Errors[0].Text != expectedError {
+		t.Errorf("expected error: %#v, got %#v", expectedError, c.Errors[0].Text)
+	}
 }
 
 func setupCompiler(t *testing.T) *Compiler {


### PR DESCRIPTION
This introduces the following changes.:

* The `Error` code now has a `Code` field that exposes the YARA API error code to Go users, and also exposes the error codes as constants that can be used in Go code (example: `err.Code == yara.ERROR_TIMEOUT`). Sometimes is useful to get a numeric error code instead of a text string.

* When `Error` is converted to a string, it includes the name of the rule causing the error. For example, instead of getting an error like `syntax error, unexpected identifier, expecting <condition>`, you get `rule \"foo\": syntax error, unexpected identifier, expecting <condition>`.