### PR TITLE
fix: do not store rule object from compiler callback permanently

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -46,9 +46,8 @@ func compilerCallback(errorLevel C.int, filename *C.char, linenumber C.int, rule
 		Text:     text,
 	}
 	if rule != nil {
-		// Rule object implicitly relies on the compiler object and is destroyed when the compiler is destroyed.
-		// Save a reference to the compiler to prevent that from happening.
-		msg.Rule = &Rule{cptr: rule, owner: c}
+		// The rule object MUST NOT be stored persistently; it is only valid during the callback.
+		msg.Rule = C.GoString(C.rule_identifier(rule))
 	}
 	switch errorLevel {
 	case C.YARA_ERROR_LEVEL_ERROR:
@@ -78,7 +77,7 @@ type CompilerMessage struct {
 	Filename string
 	Line     int
 	Text     string
-	Rule     *Rule
+	Rule     string
 }
 
 // NewCompiler creates a YARA compiler.


### PR DESCRIPTION
The YR_RULE* pointer from the compiler callback originates from `yr_arena_get_ptr`, which refers to `yr_arena_ref_to_ptr`, which has the following comment:
> This pointer is valid only until the next call to any of the functions that allocates space in the buffer where the data resides, like yr_arena_allocate_xxx and yr_arena_write_xxx.

Since the compiler may (and is highly likely to) allocate more data in the arena, we can not persistently store this pointer and may only use it during the callback (though this is sadly undocumented).